### PR TITLE
Adding the possibility to send an email with a template stored in mailgun

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ if (template && template instanceof MailgunTemplate) {
 			console.error(error);
 		});
 }
+```
 
 
 ### Sending with a Template stored in Mailgun

--- a/README.md
+++ b/README.md
@@ -237,7 +237,13 @@ if (template && template instanceof MailgunTemplate) {
 			console.error(error);
 		});
 }
+```typescript
+
 ```
+
+### Sending with a Template stored in Mailgun
+To send via a pre-stored template, just leave the body empty and define the template name via:
+`sendOptions.template === 'TEMPLATENAME'`
 
 ### Loading Header & Footer from HTML Templates
 

--- a/README.md
+++ b/README.md
@@ -237,13 +237,15 @@ if (template && template instanceof MailgunTemplate) {
 			console.error(error);
 		});
 }
-```typescript
 
-```
 
 ### Sending with a Template stored in Mailgun
 To send via a pre-stored template, just leave the body empty and define the template name via:
-`sendOptions.template === 'TEMPLATENAME'`
+
+```typescript
+	sendOptions.template === 'TEMPLATENAME'
+```
+
 
 ### Loading Header & Footer from HTML Templates
 

--- a/src/ts-mailgun.ts
+++ b/src/ts-mailgun.ts
@@ -204,7 +204,9 @@ export class NodeMailgun {
 
 			message = Object.assign(message, sendOptions);
 			
-			if (!body || sendOptions?.template) delete message.html;
+			if (!body || sendOptions?.template) {
+				delete message.html;
+			}
 
 			// Send email
 			this.mailgun.messages().send(message, (error, result) => {

--- a/src/ts-mailgun.ts
+++ b/src/ts-mailgun.ts
@@ -160,7 +160,7 @@ export class NodeMailgun {
 	public send(
 		to: string | string[],
 		subject: string,
-		body: string,
+		body?: string,
 		templateVars = {},
 		sendOptions = {}
 	): Promise<any> {
@@ -203,6 +203,8 @@ export class NodeMailgun {
 			};
 
 			message = Object.assign(message, sendOptions);
+			
+			if (!body || sendOptions?.template) delete message.html;
 
 			// Send email
 			this.mailgun.messages().send(message, (error, result) => {


### PR DESCRIPTION
Mailgun lets you predefine templates via the templates API. This pull request lets you send out these templates.

https://documentation.mailgun.com/en/latest/user_manual.html#templates